### PR TITLE
Fix: Add disabled styles for all components

### DIFF
--- a/src/components/form/CurrencyInput.tsx
+++ b/src/components/form/CurrencyInput.tsx
@@ -74,7 +74,7 @@ export function CurrencyInput({
   return (
     <input
       name={name}
-      className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500"
+      className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
       inputMode="numeric"
       type="text"
       onChange={(e) => {

--- a/src/components/form/Select.tsx
+++ b/src/components/form/Select.tsx
@@ -35,7 +35,7 @@ const SelectRoot = ({
     {...props}
   >
     <InputRoot className="h-10 w-full">
-      <SelectPrimitive.Trigger className="outline-0 bg-transparent flex-1 flex items-center space-x-2 text-slate-900 text-sm data-[placeholder]:text-slate-500">
+      <SelectPrimitive.Trigger className="outline-0 bg-transparent flex-1 flex items-center space-x-2 text-slate-900 text-sm data-[placeholder]:text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed">
         <SelectPrimitive.Value placeholder={placeholder} />
         <SelectPrimitive.Icon className="text-slate-500">
           <RxChevronDown />

--- a/src/components/form/SmartField/index.tsx
+++ b/src/components/form/SmartField/index.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "../Checkbox";
 import { CheckLabel } from "../atoms/CheckLabel";
 import { RadioGroup } from "../RadioGroup";
 import { Slider } from "../Slider";
+import clsx from "clsx";
 
 interface SmartFieldProps extends IFieldHandlersProps {
   config: FieldConfig;
@@ -119,7 +120,14 @@ export function SmartField({
                     }}
                     disabled={disabled}
                   />
-                  <CheckLabel htmlFor={option.value}>{option.label}</CheckLabel>
+                  <CheckLabel
+                    htmlFor={option.value}
+                    className={clsx({
+                      "opacity-50 cursor-not-allowed": disabled,
+                    })}
+                  >
+                    {option.label}
+                  </CheckLabel>
                 </div>
               ))}
           </div>
@@ -154,7 +162,14 @@ export function SmartField({
               disabled={disabled}
             />
             {"checkLabel" in config && (
-              <CheckLabel htmlFor={config.id}>{config.checkLabel}</CheckLabel>
+              <CheckLabel
+                htmlFor={config.id}
+                className={clsx({
+                  "opacity-50 cursor-not-allowed": disabled,
+                })}
+              >
+                {config.checkLabel}
+              </CheckLabel>
             )}
           </div>
         );

--- a/src/components/form/TextInput.tsx
+++ b/src/components/form/TextInput.tsx
@@ -33,7 +33,7 @@ TextInputIcon.displayName = "TextInput.Icon";
 function TextInputInput(props: TextInputInputProps) {
   return (
     <input
-      className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500"
+      className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
       {...props}
     />
   );

--- a/src/components/form/Textarea.tsx
+++ b/src/components/form/Textarea.tsx
@@ -8,7 +8,7 @@ export function Textarea({ className, ...props }: TextareaProps) {
   return (
     <InputRoot className={className}>
       <textarea
-        className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500"
+        className="outline-0 bg-transparent flex-1 text-slate-900 text-sm placeholder:text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
         {...props}
       ></textarea>
     </InputRoot>

--- a/src/components/form/atoms/CheckLabel.tsx
+++ b/src/components/form/atoms/CheckLabel.tsx
@@ -1,10 +1,11 @@
-export function CheckLabel(
-  props: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, "className">
-) {
+export function CheckLabel(props: React.LabelHTMLAttributes<HTMLLabelElement>) {
   return (
     <label
       {...props}
-      className="inline-flex h-6 align-top items-center text-slate-900 text-sm ml-2"
+      className={
+        "inline-flex h-6 align-top items-center text-slate-900 text-sm ml-2 " +
+        props.className
+      }
     />
   );
 }

--- a/src/examples/SmartFieldExamples.tsx
+++ b/src/examples/SmartFieldExamples.tsx
@@ -145,9 +145,9 @@ export function SmartFieldExamples() {
   return (
     <div className="p-8 space-y-4">
       <h1 className="font-bold">All Smart Fields</h1>
-      <div>
+      <div className="flex border-b pb-4">
         <Checkbox checked={disabled} onChange={() => setDisabled(!disabled)} />
-        <CheckLabel>Disabled</CheckLabel>
+        <CheckLabel>Disabled all fields</CheckLabel>
       </div>
       {formFields.map((field) => (
         <SmartField

--- a/src/examples/SmartFieldExamples.tsx
+++ b/src/examples/SmartFieldExamples.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { SmartField } from "../components/form/SmartField";
 import { FieldConfig, FormFields } from "../components/form/SmartField/types";
 import { MdMailOutline } from "react-icons/md";
+import { Checkbox } from "../components/form/Checkbox";
+import { CheckLabel } from "../components/form/atoms/CheckLabel";
 
 const formFields: FieldConfig[] = [
   {
@@ -138,11 +140,15 @@ export function SmartFieldExamples() {
     }
     return acc;
   }, {} as FormFields);
-  const disabled = false;
+  const [disabled, setDisabled] = useState(false);
   const [data, setData] = useState(initialFormState);
   return (
     <div className="p-8 space-y-4">
       <h1 className="font-bold">All Smart Fields</h1>
+      <div>
+        <Checkbox checked={disabled} onChange={() => setDisabled(!disabled)} />
+        <CheckLabel>Disabled</CheckLabel>
+      </div>
       {formFields.map((field) => (
         <SmartField
           key={field.id}


### PR DESCRIPTION
# Disabled fields

Added a control to disable fields at SmartFieldExamples
Componets set with opacity: 50% and cursor as not allowed;

Note: new components will have to match an acceptance criteria

## Preview:
![image](https://github.com/user-attachments/assets/6a1687f2-5f9d-4839-9851-5877e6d16b40)
![image](https://github.com/user-attachments/assets/306c02dc-3df0-45bf-ac6d-5f06fe7fee1d)
